### PR TITLE
chore: make repo forkable with GHCR and github.repository_owner

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,47 @@
+name: Build and Push Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "images/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and Push to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push ubuntu image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/ubuntu
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/ubuntu:latest
+
+      - name: Build and push dind image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./images/dind
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/dind:latest

--- a/.github/workflows/composite.yml
+++ b/.github/workflows/composite.yml
@@ -6,22 +6,22 @@ on:
 
 env:
   DOCKER_REGISTRY_URL: ghcr.io
-  DOCKER_REGISTRY_USER: a-magdy
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   run-composite-action-succeeds:
     name: Composite (Succeeds)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: a-magdy/test-gh-docker-actions/test-gh-docker/composite@main
         with:
-          image: ${{ env.DOCKER_REGISTRY_URL }}/${{ env.DOCKER_REGISTRY_USER }}/ubuntu
+          image: ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -9,53 +9,48 @@ on:
 
 env:
   DOCKER_REGISTRY_URL: ghcr.io
-  DOCKER_REGISTRY_USER: a-magdy
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   run-composite-action-succeeds:
     name: Composite (Succeeds)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: a-magdy/test-gh-docker-actions/test-gh-docker/composite@main
         with:
-          image: ${{ env.DOCKER_REGISTRY_URL }}/${{ env.DOCKER_REGISTRY_USER }}/ubuntu
+          image: ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu
 
   run-dockerfile-action-fails:
     name: Dockerfile (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: a-magdy/test-gh-docker-actions/test-gh-docker/dockerfile@main
+
   run-dockerfile-action-succeeds:
     name: Dockerfile (Succeeds)
     runs-on: ubuntu-latest
     needs: run-dockerfile-action-fails
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
@@ -67,34 +62,31 @@ jobs:
     name: Image (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: a-magdy/test-gh-docker-actions/test-gh-docker/image@main
+
   run-image-action-succeeds:
     name: Image (Succeeds)
     runs-on: ubuntu-latest
     needs: run-image-action-fails
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
 
-      - run: docker pull ghcr.io/a-magdy/ubuntu
+      # Pre-pull required: `image: docker://` in action.yml doesn't auto-pull private images.
+      # See: https://github.com/orgs/community/discussions/26399
+      - run: docker pull ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu
 
       - uses: ./test-gh-docker/image
 
@@ -102,61 +94,54 @@ jobs:
     name: DinD - Image (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     container:
-      image: ghcr.io/a-magdy/dind
+      image: ghcr.io/${{ github.repository_owner }}/dind
       credentials:
-        username: ${{ env.DOCKER_REGISTRY_USER }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged # For Docker-in-Docker if needed
+      options: --privileged
     steps:
       - name: Docker Registry Login
         uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Image Action
         uses: a-magdy/test-gh-docker-actions/test-gh-docker/image@main
+
   dind-run-dockerfile-fails:
     name: DinD - Dockerfile (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     container:
-      image: ghcr.io/a-magdy/dind
+      image: ghcr.io/${{ github.repository_owner }}/dind
       credentials:
-        username: ${{ env.DOCKER_REGISTRY_USER }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged # For Docker-in-Docker if needed
+      options: --privileged
     steps:
       - name: Docker Registry Login
         uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Dockerfile Action
         uses: a-magdy/test-gh-docker-actions/test-gh-docker/dockerfile@main
+
   dind-composite-action-succeeds:
     name: DinD - Composite (Succeeds)
     runs-on: ubuntu-latest
     needs: [dind-run-image-fails, dind-run-dockerfile-fails]
-    permissions:
-      contents: read
-      packages: read
     container:
-      image: ghcr.io/a-magdy/dind
+      image: ghcr.io/${{ github.repository_owner }}/dind
       credentials:
-        username: ${{ env.DOCKER_REGISTRY_USER }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged # For Docker-in-Docker if needed
+      options: --privileged
     steps:
       - uses: actions/checkout@v4
 
@@ -164,9 +149,9 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test image
         shell: bash
-        run: docker run --rm ghcr.io/a-magdy/ubuntu echo "Hello from Docker in DinD"
+        run: docker run --rm ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu echo "Hello from Docker in DinD"

--- a/.github/workflows/dind.yml
+++ b/.github/workflows/dind.yml
@@ -6,28 +6,28 @@ on:
 
 env:
   DOCKER_REGISTRY_URL: ghcr.io
-  DOCKER_REGISTRY_USER: a-magdy
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   dind-run-image-fails:
     name: DinD - Image (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     container:
-      image: ghcr.io/a-magdy/dind
+      image: ghcr.io/${{ github.repository_owner }}/dind
       credentials:
-        username: ${{ env.DOCKER_REGISTRY_USER }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged # For Docker-in-Docker if needed
+      options: --privileged
     steps:
       - name: Docker Registry Login
         uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Image Action
@@ -37,21 +37,18 @@ jobs:
     name: DinD - Dockerfile (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     container:
-      image: ghcr.io/a-magdy/dind
+      image: ghcr.io/${{ github.repository_owner }}/dind
       credentials:
-        username: ${{ env.DOCKER_REGISTRY_USER }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged # For Docker-in-Docker if needed
+      options: --privileged
     steps:
       - name: Docker Registry Login
         uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Dockerfile Action
@@ -61,15 +58,12 @@ jobs:
     name: DinD - Composite (Succeeds)
     runs-on: ubuntu-latest
     needs: [dind-run-image-fails, dind-run-dockerfile-fails]
-    permissions:
-      contents: read
-      packages: read
     container:
-      image: ghcr.io/a-magdy/dind
+      image: ghcr.io/${{ github.repository_owner }}/dind
       credentials:
-        username: ${{ env.DOCKER_REGISTRY_USER }}
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --privileged # For Docker-in-Docker if needed
+      options: --privileged
     steps:
       - uses: actions/checkout@v4
 
@@ -77,9 +71,9 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Test image
         shell: bash
-        run: docker run --rm ghcr.io/a-magdy/ubuntu echo "Hello from Docker in DinD"
+        run: docker run --rm ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu echo "Hello from Docker in DinD"

--- a/.github/workflows/dockerfile.yml
+++ b/.github/workflows/dockerfile.yml
@@ -6,21 +6,21 @@ on:
 
 env:
   DOCKER_REGISTRY_URL: ghcr.io
-  DOCKER_REGISTRY_USER: a-magdy
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   run-dockerfile-action-fails:
     name: Dockerfile (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: a-magdy/test-gh-docker-actions/test-gh-docker/dockerfile@main
@@ -29,14 +29,11 @@ jobs:
     name: Dockerfile (Succeeds)
     runs-on: ubuntu-latest
     needs: run-dockerfile-action-fails
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,21 +6,21 @@ on:
 
 env:
   DOCKER_REGISTRY_URL: ghcr.io
-  DOCKER_REGISTRY_USER: a-magdy
+
+permissions:
+  contents: read
+  packages: read
 
 jobs:
   run-image-action-fails:
     name: Image (Fails)
     runs-on: ubuntu-latest
     continue-on-error: true
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: a-magdy/test-gh-docker-actions/test-gh-docker/image@main
@@ -29,18 +29,17 @@ jobs:
     name: Image (Succeeds)
     runs-on: ubuntu-latest
     needs: run-image-action-fails
-    permissions:
-      contents: read
-      packages: read
     steps:
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.DOCKER_REGISTRY_URL }}
-          username: ${{ env.DOCKER_REGISTRY_USER }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4
 
-      - run: docker pull ghcr.io/a-magdy/ubuntu
+      # Pre-pull required: `image: docker://` in action.yml doesn't auto-pull private images.
+      # See: https://github.com/orgs/community/discussions/26399
+      - run: docker pull ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu
 
       - uses: ./test-gh-docker/image

--- a/README.md
+++ b/README.md
@@ -126,3 +126,23 @@ This affects enterprise users with private registries and forces:
 
 - [josh-ops - Create a Docker Container Action Hosted in a Private Image Registry](https://josh-ops.com/posts/github-actions-docker-actions-private-registry/)
 - [moby/moby - Issue 38591](https://github.com/moby/moby/issues/38591) (potentially relevant)
+
+---
+
+## Fork Setup
+
+This repository is designed to be forkable. After forking:
+
+1. **Run `build-images` workflow** — Go to **Actions → Build and Push Images** and trigger it manually (`workflow_dispatch`). This builds the `ubuntu` and `dind` images from `images/` and pushes them to your GHCR namespace:
+   - `ghcr.io/YOUR-ORG/ubuntu:latest`
+   - `ghcr.io/YOUR-ORG/dind:latest`
+
+2. **(Optional) Make packages public** — In your GHCR package settings, set both packages to **Public** to avoid needing credentials for pulls.
+
+3. **Update hardcoded owner refs** — Two files contain a literal `a-magdy` that cannot use expressions:
+   - `test-gh-docker/dockerfile/Dockerfile` — update the `FROM` line
+   - `test-gh-docker/image/action.yml` — update the `image:` value
+
+   > All workflow files use `${{ github.repository_owner }}` and `${{ github.actor }}` automatically — no changes needed there.
+
+4. **Run any workflow** — Authentication uses `GITHUB_TOKEN` (built-in, no secrets to configure).

--- a/images/dind/Dockerfile
+++ b/images/dind/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker:28-dind
+
+RUN apk update && apk upgrade && apk add --no-cache \
+    bash git openssh-client curl jq

--- a/images/ubuntu/Dockerfile
+++ b/images/ubuntu/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+CMD ["echo", "Hello from ubuntu image"]

--- a/test-gh-docker/dockerfile/Dockerfile
+++ b/test-gh-docker/dockerfile/Dockerfile
@@ -1,3 +1,4 @@
+# Forks: change 'a-magdy' below to your org/user after running the build-images workflow.
 FROM ghcr.io/a-magdy/ubuntu
 
 RUN echo "Hello from the Dockerfile!"

--- a/test-gh-docker/image/action.yml
+++ b/test-gh-docker/image/action.yml
@@ -1,5 +1,8 @@
 name: "Docker Image Private Registry"
 description: "Test Docker Image action with private registry"
+# Forks: change 'a-magdy' in the image ref below to your org/user after running build-images.
+# Note: `image: docker://` fields do not support expressions — this must be a literal value.
+# See: https://github.com/orgs/community/discussions/26399
 runs:
   using: "docker"
   image: "docker://ghcr.io/a-magdy/ubuntu"


### PR DESCRIPTION
## Summary

This PR makes the repository fully forkable without needing to edit code, by replacing the hardcoded `a-magdy` owner references with `github.repository_owner` / `github.actor` expressions.

## Changes

### New: Image source + build workflow
- `images/ubuntu/Dockerfile` and `images/dind/Dockerfile` — source for the GHCR images the workflows depend on (previously these had no build source in the repo)
- `.github/workflows/build-images.yml` — builds and pushes both images to GHCR using `GITHUB_TOKEN`, no extra secrets needed

### Fix: Hardcoded owner references
All 5 workflow files previously had `DOCKER_REGISTRY_USER: a-magdy` as a static env var (workflow-level `env:` doesn't support expressions). Replaced with:
- `${{ github.actor }}` for login `username:` and container `credentials.username:`
- `${{ github.repository_owner }}` for all image name references
- Fixed hardcoded `docker pull ghcr.io/a-magdy/ubuntu` to use `${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu`

### Improve: Permissions moved to workflow level
All jobs in each of the 5 workflow files had identical `permissions: contents: read, packages: read` blocks. Moved to a single workflow-level block in each file.

### Docs: Fork comments + README quickstart
- Added fork comments to `test-gh-docker/dockerfile/Dockerfile` and `test-gh-docker/image/action.yml` (these use literal `image:` fields that can't use expressions)
- Appended a **Fork Setup** section to the README

## Fork setup after merging
1. Fork the repo
2. Run **Actions → Build and Push Images** (`workflow_dispatch`)
3. Update the 2 hardcoded `a-magdy` refs in `test-gh-docker/` (noted with comments)
4. Run any workflow — only `GITHUB_TOKEN` is needed