### PR TITLE
fix: ensure images exist before test jobs run

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "images/**"
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -4,8 +4,13 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    # Ignore image-only pushes — the orchestrator handles build+test sequencing.
+    paths-ignore:
+      - "images/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "images/**"
 
 env:
   DOCKER_REGISTRY_URL: ghcr.io

--- a/.github/workflows/comprehensive.yml
+++ b/.github/workflows/comprehensive.yml
@@ -159,4 +159,4 @@ jobs:
 
       - name: Test image
         shell: bash
-        run: docker run --rm ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu echo "Hello from Docker in DinD"
+        run: docker run --rm --platform linux/amd64 ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu echo "Hello from Docker in DinD"

--- a/.github/workflows/dind.yml
+++ b/.github/workflows/dind.yml
@@ -76,4 +76,4 @@ jobs:
 
       - name: Test image
         shell: bash
-        run: docker run --rm ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu echo "Hello from Docker in DinD"
+        run: docker run --rm --platform linux/amd64 ${{ env.DOCKER_REGISTRY_URL }}/${{ github.repository_owner }}/ubuntu echo "Hello from Docker in DinD"

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -8,22 +8,36 @@ on:
     branches: [main]
 
 jobs:
+  # Ensure images are present in GHCR before running any test.
+  # On first push (or after images/ changes), this builds and pushes them.
+  # On subsequent pushes the build is a no-op cache hit.
+  build-images:
+    name: Build Images
+    uses: ./.github/workflows/build-images.yml
+    permissions:
+      contents: read
+      packages: write
+
   test-composite:
     name: Composite
+    needs: build-images
     uses: ./.github/workflows/composite.yml
     secrets: inherit
 
   test-dockerfile:
     name: Dockerfile
+    needs: build-images
     uses: ./.github/workflows/dockerfile.yml
     secrets: inherit
 
   test-image:
     name: Image
+    needs: build-images
     uses: ./.github/workflows/image.yml
     secrets: inherit
 
   test-dind:
     name: Dind
+    needs: build-images
     uses: ./.github/workflows/dind.yml
     secrets: inherit


### PR DESCRIPTION
The orchestrator now calls build-images as a prerequisite job before any test workflow runs. This fixes the bootstrap problem where a first push would trigger test jobs before the GHCR images were available.

- Add workflow_call trigger to build-images.yml so orchestrator can call it as a reusable workflow
- In orchestrator.yml, add build-images job and make all four test jobs depend on it via needs: build-images
- In comprehensive.yml, add paths-ignore for images/** so it does not fire on image-only pushes (the orchestrator handles those with proper sequencing)